### PR TITLE
[#1] python 을 exe 로 설치하고도 관련 dependencies 를 설치할 필요가 없는 방법 연구

### DIFF
--- a/scripts/install/installer.bat
+++ b/scripts/install/installer.bat
@@ -1,0 +1,2 @@
+cd ../..
+pyinstaller --onefile main.py


### PR DESCRIPTION
pyinstaller 를 사용할 경우 알아서 openCV 를 설치해줍니다. 
외부 컴퓨터에 exe 를 실행하여 실험 완료되었습니다.
외부 라이브러리까지 모두 포함시키는지는 import 마다 확인이 필요합니다.